### PR TITLE
Add `ActiveRecord` Integration

### DIFF
--- a/lib/map/integrations/active_record.rb
+++ b/lib/map/integrations/active_record.rb
@@ -2,25 +2,139 @@
 class Map
   module Integrations
     module ActiveRecord
-      def to_map( include_related = false )
-        attrs = attributes.dup
+      def self.included( klass )
+        klass.extend ClassMethods
+      end
 
-        reflections.each do | key , reflection |
-          associated = send key
-          attrs[ key ] = case
-                           when reflection.collection?
-                             associated.map { | related | related.attributes }
-                           else
-                             associated.attributes
-                         end
-        end if include_related
+      module ClassMethods
+        def to_map( record , *args )
+          # prep
+          model         = record.class
+          map           = Map.new
+          map[ :model ] = model.name.underscore
+          map[ :id ]    = record.id
 
-        Map.for attrs
+          # yank out options if they are patently obvious...
+          if args.size == 2 and args.first.is_a?( Array ) and args.last.is_a?( Hash )
+            options = Map.for args.last
+            args = args.first
+          else
+            options = nil
+          end
+
+          # get base to_dao from class
+          base = column_names
+
+          # available options keys
+          opts = %w( include includes with exclude excludes without )
+
+          # proc to remove options
+          extract_options =
+            proc do |array|
+              to_return = Map.new
+              last = array.last
+              if last.is_a?( Hash )
+                last = Map.for last
+                if opts.any? { | opt | last.has_key? opt }
+                  array.pop
+                  to_return = last
+                end
+              end
+              to_return
+            end
+
+          # handle case where options are bundled in args...
+          options ||= extract_options[args]
+
+          # use base options iff none provided
+          base_options = extract_options[base]
+          if options.blank? and !base_options.blank?
+            options = base_options
+          end
+
+          # refine the args with includes iff found in options
+          include_opts = [ :include , :includes , :with ]
+          if options.any? { | option | include_opts.include? option.to_sym }
+            args.replace( base ) if args.empty?
+            args.push( options[ :include ] )  if options[ :include ]
+            args.push( options[ :includes ] ) if options[ :includes ]
+            args.push( options[ :with ] )     if options[ :with ]
+          end
+
+          # take passed in args or model defaults
+          list = args.empty? ? base : args
+          list = column_names if list.empty?
+
+          # proc to ensure we're all mapped out
+          map_nested =
+            proc do | value , *args |
+              if value.is_a?( Array )
+                value.map { | v | map_nested[ v , *args ] }
+              else
+                if value.respond_to? :to_map
+                  value.to_map *args
+                else
+                  value
+                end
+              end
+            end
+
+          # okay - go!
+          list.flatten.each do | attr |
+            if attr.is_a?( Array )
+              related , *argv = attr
+              v = record.send related
+              value = map_nested[ value , *argv ]
+              map[ related ] = value
+              next
+            end
+
+            if attr.is_a?( Hash )
+              attr.each do | related , argv |
+                v = record.send related
+                argv = !argv.is_a?( Array ) ? [ argv ] : argv
+                value = map_nested[ v , *argv ]
+                map[ related ] = value
+              end
+              next
+            end
+
+            value = record.send attr
+
+            if value.respond_to?( :to_map )
+              map[ attr ] = value.to_map
+              next
+            end
+
+            if value.is_a?( Array )
+              map[ attr ] = value.map &map_nested
+              next
+            end
+
+            map[ attr ] = value
+          end
+
+          # refine the map with excludes iff passed as options
+          exclude_opts = [ :exclude , :excludes , :without ]
+          if options.any? { | option | exclude_opts.include? option.to_sym }
+            [ options[ :exclude ] , options[ :excludes ] , options[ :without ] ].each do | paths |
+              paths = Array paths
+              next if paths.blank?
+              paths.each { | path | map.rm path }
+            end
+          end
+
+          map
+        end
+      end
+
+      def to_map( *args )
+        self.class.to_map self , *args
       end
     end
   end
 end
 
 if defined?( ActiveRecord::Base )
-  ActiveRecord::Base.send( :include , Map::Integrations::ActiveRecord )
+  ActiveRecord::Base.send :include , Map::Integrations::ActiveRecord
 end

--- a/test/functional/active_record_integration_test.rb
+++ b/test/functional/active_record_integration_test.rb
@@ -11,26 +11,82 @@ Testing Map::Integrations::ActiveRecord do
   end
 
   testing 'calling to_map includes only attributes by default' do
-    instance         = model_instance
-    attributes_keys  = instance.attributes.keys
-    reflections_keys = instance.reflections.keys
-    mapped           = assert{ instance.to_map }
+    instance        = model_instance
+    attributes_keys = instance.class.column_names
+    mapped          = assert{ instance.to_map }
     assert{ attributes_keys.all? { | key | mapped.has_key? key } }
-    assert{ reflections_keys.all? { | key | ! mapped.has_key?( key ) } }
   end
 
-  testing 'calling to_map with true includes relations' do
-    instance         = model_instance
-    reflections_keys = instance.reflections.keys
-    mapped           = assert{ instance.to_map( true ) }
-    assert{ reflections_keys.all? { | key | mapped.has_key? key } }
+  testing 'calling to_map with include-type options includes relations' do
+    instance = model_instance
+    include_opts = [ :include , :includes , :with ]
+
+    include_opts.each do | include_opt |
+      key    = :r1
+      mapped = assert{ instance.to_map( include_opt => key ) }
+      assert{ mapped.has_key? key }
+    end
+  end
+
+  testing 'calling to_map with exclude-type options excludes relations' do
+    instance = model_instance
+    exclude_opts = [ :exclude , :excludes , :without ]
+
+    exclude_opts.each do | exclude_opt |
+      key    = :name
+      mapped = assert{ instance.to_map( exclude_opt => key ) }
+      assert{ !mapped.has_key?( key ) }
+    end
+  end
+
+  testing 'calling to_map with `with` option pointing at non-column method name includes returned val' do
+    instance    = model_instance
+    include_opt = :with
+    key         = :bogus
+    val         = instance.send key
+    mapped      = assert{ instance.to_map( include_opt => key ) }
+    assert{ mapped.send( key ) == val }
+  end
+
+  testing 'calling with multiple option types performs all' do
+    instance    = model_instance
+    with_key    = :bogus
+    without_key = :model
+    mapped      = assert{ instance.to_map( :includes => with_key , :without => without_key ) }
+    assert{ mapped.has_key? with_key }
+    assert{ !mapped.has_key?( without_key ) }
+  end
+
+  testing 'calling with multiple of the same option types performs all' do
+    instance       = model_instance
+    with_key       = :bogus
+    other_with_key = :r2
+    mapped         = assert{ instance.to_map( :includes => with_key , :with => other_with_key ) }
+    assert{ mapped.has_key? with_key }
+    assert{ mapped.has_key? other_with_key }
+  end
+
+  testing 'nesting to_map options on relation key that responds to to_map respects options' do
+    instance        = model_instance true
+    relation        = :r1
+    nested_with_key = :bogus
+    mapped          = assert{ instance.to_map( :include => { relation => { :with => nested_with_key } } ) }
+    assert{ mapped[ relation ].has_key? nested_with_key }
+  end
+
+  testing 'including multiple where one has options respects all' do
+    instance = model_instance true
+    mapped   = assert{ instance.to_map( :include => [ :r1 , { :r2 => { :with => :bogus } } ] ) }
+    assert{ mapped.has_key? :r1 }
+    assert{ mapped.has_key? :r2 }
+    assert{ mapped[ :r2 ].all? { | r | r.has_key? :bogus } }
   end
 
 protected
 
-  def model_instance
-    klass = assert{ Class.new( ActiveRecord::Base ) }
-    assert{ klass.new }
+  def model_instance( *args )
+    klass = assert{ Class.new ActiveRecord::Base }
+    assert{ klass.new *args }
   end
 end
 

--- a/test/lib/core_ext.rb
+++ b/test/lib/core_ext.rb
@@ -1,0 +1,11 @@
+class Object
+  def blank?
+    nil? or empty?
+  end
+end
+
+class String
+  def underscore
+    self
+  end
+end

--- a/test/lib/fake_active_record.rb
+++ b/test/lib/fake_active_record.rb
@@ -1,28 +1,59 @@
+require 'core_ext'
+
 module ActiveRecord
   class Base
-    def attributes
-      { :k1 => 'v1' , :k2 => 'v2' }
+    NAMES = %w(
+      Dog
+      DogWalker
+    )
+
+    def self.column_names
+      %w(
+        id
+        name
+      )
     end
 
-    def r1
-      Association.new
+    def self.name
+      NAMES[ rand( 50 ) % 2 ]
     end
 
-    def r2
-      [ Association.new , Association.new ]
-    end
-
-    def reflections
+    def self.reflections
       {
         :r1 => Reflection.new,
         :r2 => Reflection.new( true )
       }
     end
 
-    class Association
-      def attributes
-        { :ak1 => 'v1' , :ak2 => 'v2' }
-      end
+    def initialize( *args , &block )
+      options = Map.opts args
+      @has_relations = options.has_relations rescue args.first || false
+    end
+
+    def bogus
+      'wut'
+    end
+
+    def id
+      rand 10000
+    end
+
+    def name
+      inspect
+    end
+
+    def r1
+      return nil unless @has_relations
+      self.class.new
+    end
+
+    def r2
+      return [] unless @has_relations
+      [ self.class.new , self.class.new ]
+    end
+
+    def reflections
+      self.class.reflections
     end
 
     class Reflection


### PR DESCRIPTION
Commit: 'add support for a `to_map` method on `ActiveRecord::Base` descendants when `require "map/integrations/active_record"` is called'

This adds a sane, generic implementation of a `to_map` method to descendants of `ActiveRecord::Base`.

Calling `require "map/integrations/active_record"` is required.

See: [https://gist.github.com/2347973](https://gist.github.com/2347973)
