### PR TITLE
Make Map ruby 1.9 -w clean.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ def run_tests!(which = nil)
 
   test_rbs.each_with_index do |test_rb, index|
     testno = index + 1
-    command = "#{ This.ruby } -I ./lib -I ./test/lib #{ test_rb }"
+    command = "#{ This.ruby } -w -I ./lib -I ./test/lib #{ test_rb }"
 
     puts
     say(div, :color => :cyan, :bold => true)

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -104,7 +104,6 @@ class Map < Hash
   #
     def each_pair(*args, &block)
       size = args.size
-      parity = size % 2 == 0 ? :even : :odd
       first = args.first
 
       if block.nil?
@@ -145,8 +144,8 @@ class Map < Hash
 
       if array_of_pairs
         args.each do |pair|
-          key, val, *ignored = pair
-          block.call(key, val)
+          k, v = pair[0..1]
+          block.call(k, v)
         end
       else
         0.step(args.size - 1, 2) do |a|
@@ -674,7 +673,7 @@ class Map < Hash
     end
 
     if !Map.collection_has?(collection, key) && block_given?
-      default_value = yield
+      yield #default_value
     else
       Map.collection_key(collection, key)
     end
@@ -811,11 +810,11 @@ class Map < Hash
         hash[key] = value
     end
 
-    strategy = hash.map{|key, value| [Array(key), value]}
+    strategy = hash.map{|skey, svalue| [Array(skey), svalue]}
 
-    strategy.each do |key, value|
-      leaf_for(key, :autovivify => true) do |leaf, k|
-        Map.collection_set(leaf, k, value)
+    strategy.each do |skey, svalue|
+      leaf_for(skey, :autovivify => true) do |leaf, k|
+        Map.collection_set(leaf, k, svalue)
       end
     end
 
@@ -837,12 +836,12 @@ class Map < Hash
 
     exploded = Map.explode(hash)
 
-    exploded[:branches].each do |key, type|
-      set(key, type.new) unless get(key).is_a?(type)
+    exploded[:branches].each do |bkey, btype|
+      set(bkey, btype.new) unless get(bkey).is_a?(btype)
     end
 
-    exploded[:leaves].each do |key, value|
-      set(key, value)
+    exploded[:leaves].each do |lkey, lvalue|
+      set(lkey, lvalue)
     end
 
     self
@@ -945,13 +944,13 @@ class Map < Hash
     paths, path = args.partition{|arg| arg.is_a?(Array)}
     paths.push(path)
 
-    paths.each do |path|
-      if path.size == 1
-        delete(*path)
+    paths.each do |p|
+      if p.size == 1
+        delete(*p)
         next
       end
 
-      branch, leaf = path[0..-2], path[-1]
+      branch, leaf = p[0..-2], p[-1]
       collection = get(branch)
 
       case collection
@@ -962,7 +961,7 @@ class Map < Hash
           index = leaf
           collection.delete_at(index)
         else
-          raise(IndexError, "(#{ collection.inspect }).rm(#{ path.inspect })")
+          raise(IndexError, "(#{ collection.inspect }).rm(#{ p.inspect })")
       end
     end
     paths
@@ -1099,19 +1098,19 @@ class Map < Hash
   end
 
   def depth_first_each(*args, &block)
-    Map.depth_first_each(enumerable=self, *args, &block)
+    Map.depth_first_each(self, *args, &block)
   end
 
   def depth_first_keys(*args, &block)
-    Map.depth_first_keys(enumerable=self, *args, &block)
+    Map.depth_first_keys(self, *args, &block)
   end
 
   def depth_first_values(*args, &block)
-    Map.depth_first_values(enumerable=self, *args, &block)
+    Map.depth_first_values(self, *args, &block)
   end
 
   def breadth_first_each(*args, &block)
-    Map.breadth_first_each(enumerable=self, *args, &block)
+    Map.breadth_first_each(self, *args, &block)
   end
 
   def contains(other)

--- a/lib/map/struct.rb
+++ b/lib/map/struct.rb
@@ -43,7 +43,7 @@ class Map
   end
 
   def struct
-    @struct ||= Struct.new(map=self)
+    @struct ||= Struct.new(self)
   end
 
   def Map.struct(*args, &block)

--- a/test/lib/testing.rb
+++ b/test/lib/testing.rb
@@ -34,7 +34,6 @@
       end
 
       def self.testing(*args, &block)
-        method = ["test", testno, slug_for(*args)].delete_if{|part| part.empty?}.join('_')
         define_method("test_#{ testno }_#{ slug_for(*args) }", &block)
       end
 
@@ -69,7 +68,7 @@
         __assert_raises__(*args, &block)
       end
 
-      module_eval &block
+      module_eval(&block)
       self
     end
   end

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -361,8 +361,8 @@ Testing Map do
     assert{ m[:x][:y].is_a?(Map) }
     assert{ m[:x][:y][:z] == 42.0 }
 
-    assert{ Map.new.tap{|m| m.set} =~ {} }
-    assert{ Map.new.tap{|m| m.set({})} =~ {} }
+    assert{ Map.new.tap{|nm| nm.set} =~ {} }
+    assert{ Map.new.tap{|nm| nm.set({})} =~ {} }
   end
 
   testing 'that Map#get supports providing a default value in a block' do
@@ -442,8 +442,8 @@ Testing Map do
         {"a"=>{"b"=>{"c"=>42, "d"=>42.0}}}
     end
 
-    assert{ Map.new.tap{|m| m.add} =~ {} }
-    assert{ Map.new.tap{|m| m.add({})} =~ {} }
+    assert{ Map.new.tap{|i| i.add} =~ {} }
+    assert{ Map.new.tap{|i| i.add({})} =~ {} }
   end
 
   testing 'that Map.combine is teh sweet' do
@@ -567,7 +567,6 @@ Testing Map do
 
   testing 'that maps with un-marshal-able objects can be copied' do
     open(__FILE__) do |f|
-      f
       m = Map.for(:f => f)
       assert{ m.copy }
       assert{ m.dup }


### PR DESCRIPTION
- remove unused variable
- fix shadowed variables
- remove dead code
- remove parameter ambiquity
