### PR TITLE
Fix typo in README

### DIFF
--- a/README
+++ b/README
@@ -36,8 +36,8 @@ DESCRIPTION
   m[:b] = 1
   m[:c] = 2
 
-  p m.keys #=> ['a','b','c']  ### always ordered!
-  p m.keys #=> [0,1,2]        ### always ordered!
+  p m.keys   #=> ['a','b','c']  ### always ordered!
+  p m.values #=> [0,1,2]        ### always ordered!
 
 # maps don't care about symbol vs.string keys
 #


### PR DESCRIPTION
The README file had `keys` where it should have been `values`.
