### PR TITLE
support negative array indexes deeply in get keys

### DIFF
--- a/lib/map.rb
+++ b/lib/map.rb
@@ -775,7 +775,12 @@ class Map < Hash
       case collection
         when Array
           key = (Integer(key) rescue nil)
-          (0...collection.size).include?(key) or (0...collection.size).include?((-key)-1)
+          begin
+            collection.fetch(key)
+            true
+          rescue
+            false
+          end
 
         when Hash
           collection.has_key?(key)

--- a/lib/map.rb
+++ b/lib/map.rb
@@ -774,8 +774,8 @@ class Map < Hash
     has_key =
       case collection
         when Array
-          key = (Integer(key) rescue -1)
-          (0...collection.size).include?(key)
+          key = (Integer(key) rescue nil)
+          (0...collection.size).include?(key) or (0...collection.size).include?((-key)-1)
 
         when Hash
           collection.has_key?(key)

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -361,6 +361,10 @@ Testing Map do
     assert{ m[:x][:y].is_a?(Map) }
     assert{ m[:x][:y][:z] == 42.0 }
 
+    m = Map.new(a: [b: :c])
+    assert { m.get(:a, '-1', :b) == m.get(:a, '-1').get(:b) }
+    assert { m.get(:a, '-1', :b) == :c }
+
     assert{ Map.new.tap{|nm| nm.set} =~ {} }
     assert{ Map.new.tap{|nm| nm.set({})} =~ {} }
   end

--- a/test/map_test.rb
+++ b/test/map_test.rb
@@ -361,12 +361,19 @@ Testing Map do
     assert{ m[:x][:y].is_a?(Map) }
     assert{ m[:x][:y][:z] == 42.0 }
 
+    assert{ Map.new.tap{|nm| nm.set} =~ {} }
+    assert{ Map.new.tap{|nm| nm.set({})} =~ {} }
+  end
+
+  testing 'that maps support compound key/val getting, setting, and checking with negative array indexes' do
     m = Map.new(a: [b: :c])
     assert { m.get(:a, '-1', :b) == m.get(:a, '-1').get(:b) }
     assert { m.get(:a, '-1', :b) == :c }
 
-    assert{ Map.new.tap{|nm| nm.set} =~ {} }
-    assert{ Map.new.tap{|nm| nm.set({})} =~ {} }
+    assert { m.set(:a, '-1', :b, :d) }
+    assert { m.get(:a, '-1', :b) == :d }
+
+    assert { m.has?(:a, '-1', :b) == true}
   end
 
   testing 'that Map#get supports providing a default value in a block' do


### PR DESCRIPTION
Currently in Map the behavior of the get method when negative array indexes are passed as keys differs if the negative array index is the last key or not:
Map.new(a: [b: :c]).get(:a, '-1', :b) == nil
Map.new(a: [b: :c]).get(:a, '-1').get(:b) == :c

This PR includes a change such that both cases now equal :c along with a test.
